### PR TITLE
feat: standby for shutdown operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Lighting patterns are listed below.
 |Shutdown status|lighting pattern|
 |:-----------------|:---------------|
 |Standby for shutdown |Blinks(2Hz)  |
-|Start of shutdown |Repeat the following;<br>Blinks twice at 0.2 second intervals, and the second light off for 1.5 seconds.|
+|Successful shutdown initiation |After repeating the following twice, Light off;<br>Blinks twice at 0.2 second intervals, and the second light off for 1.5 seconds.|
 
 ## Input and Output
 - input

--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
 # Lamp manager for delivery reservation
 
 ## Overview
-By changing lighting pattern of the lamp, this node notifies surrounding workers of on-demand delivery reservation status and shutdown acceptance status through `/dio_ros_driver`. 
+By changing lighting pattern of the lamp, this node notifies the following status through `/dio_ros_driver`. 
+
+1. Notify surrounding workers of on-demand delivery reservation status.
+1. Notify operator of shutdown status.
 
 Lighting patterns are listed below.
 
 |Reservation status|lighting pattern|
 |:-----------------|:---------------|
 |Not reserved      |Off             |
-|In progress       |Blink once every second |
+|In progress       |Blinks(1Hz)     |
 |Reserved          |Light up        |
-|Standby for shutdown |Blink once every 0.5 seconds |
-|Start of shutdown |Light up        |
+
+|Shutdown status|lighting pattern|
+|:-----------------|:---------------|
+|Standby for shutdown |Blinks(2Hz)  |
+|Start of shutdown |Repeat the following;<br>Blinks twice at 0.2 second intervals, and the second light off for 1.5 seconds.|
 
 ## Input and Output
 - input
-  - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine) and [shutdown_manager](https://github.com/eve-autonomy/shutdown_manager)
-    - `/delivery_reservation_lock_state` \[[autoware_state_machine_msgs/msg/StateLock](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateLock.msg)\]:<br>Reservation status for on-demand delivery. Or shutdown acceptance status.
+  - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine)
+    - `/autoware_state_machine/lock_state` \[[autoware_state_machine_msgs/msg/StateLock](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateLock.msg)\]:<br>Reservation status for on-demand delivery.
+  - from [shutdown_manager](https://github.com/eve-autonomy/shutdown_manager)
+    - `/shutdown_manager/state` \[[shutdown_manager_msgs/msg/StateShutdown](https://github.com/eve-autonomy/shutdown_manager_msgs/blob/main/msg/StateShutdown.msg)\]:<br>Shutdown status.
 - output
   - to [dio_ros_driver](https://github.com/tier4/dio_ros_driver)
     - `/dio/dout3` \[[dio_ros_driver/msg/DIOPort](https://github.com/tier4/dio_ros_driver/blob/develop/ros2/msg/DIOPort.msg)\]:<br>Digital-out assignment to a 3rd pin in [0-7] general-purpose outputs. This topic is remapped from `/delivery_reservation_lamp_out`.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # Lamp manager for delivery reservation
 
 ## Overview
-By changing lighting pattern of the lamp, this node notifies surrounding workers of on-demand delivery reservation status through `/dio_ros_driver`. 
+By changing lighting pattern of the lamp, this node notifies surrounding workers of on-demand delivery reservation status and shutdown acceptance status through `/dio_ros_driver`. 
 
 Lighting patterns are listed below.
 
 |Reservation status|lighting pattern|
 |:-----------------|:---------------|
 |Not reserved      |Off             |
-|In progress       |Blinks          |
+|In progress       |Blink once every second |
 |Reserved          |Light up        |
+|Standby for shutdown |Blink once every 0.5 seconds |
 
 ## Input and Output
 - input
-  - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine)
-    - `/autoware_state_machine/lock_state` \[[autoware_state_machine_msgs/msg/StateLock](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateLock.msg)\]:<br>Reservation status for on-demand delivery.
+  - from [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine) and [shutdown_manager](https://github.com/eve-autonomy/shutdown_manager)
+    - `/delivery_reservation_lock_state` \[[autoware_state_machine_msgs/msg/StateLock](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/StateLock.msg)\]:<br>Reservation status for on-demand delivery. Or shutdown acceptance status.
 - output
   - to [dio_ros_driver](https://github.com/tier4/dio_ros_driver)
     - `/dio/dout3` \[[dio_ros_driver/msg/DIOPort](https://github.com/tier4/dio_ros_driver/blob/develop/ros2/msg/DIOPort.msg)\]:<br>Digital-out assignment to a 3rd pin in [0-7] general-purpose outputs. This topic is remapped from `/delivery_reservation_lamp_out`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Lighting patterns are listed below.
 |In progress       |Blink once every second |
 |Reserved          |Light up        |
 |Standby for shutdown |Blink once every 0.5 seconds |
+|Start of shutdown |Light up        |
 
 ## Input and Output
 - input

--- a/docs/node_graph.pu
+++ b/docs/node_graph.pu
@@ -1,11 +1,15 @@
 @startuml
 
+left to right direction
+
 usecase "/autoware_state_machine"
+usecase "/shutdown_manager"
 usecase "/delivery_reservation_lamp_manager" #LightCoral
 usecase "/dio_ros_driver"
 
-(/autoware_state_machine) -> (/delivery_reservation_lamp_manager) : /autoware_state_machine/lock_state
+(/autoware_state_machine) --> (/delivery_reservation_lamp_manager) : /autoware_state_machine/lock_state
+(/shutdown_manager) --> (/delivery_reservation_lamp_manager) : /shutdown_manager/state
 
-(/delivery_reservation_lamp_manager) -> (/dio_ros_driver) : /dio/dout3
+(/delivery_reservation_lamp_manager) --> (/dio_ros_driver) : /dio/dout3
 
 @enduml

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -30,8 +30,8 @@ public:
 
   enum BlinkType
   {
-    FAST,
-    SLOW,
+    FAST_BLINK,
+    SLOW_BLINK,
     TWO_BLINKS
   };
 

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -37,7 +37,8 @@ public:
   rclcpp::Publisher<dio_ros_driver::msg::DIOPort>::SharedPtr pub_delivery_reservation_lamp_;
 
   // Subscription
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_state_;
+  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_reservation_lock_state_;
+  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_shutdown_state_;
 
   #define BLINK_FAST_ON_DURATION (0.5)
   #define BLINK_FAST_OFF_DURATION (0.5)
@@ -60,7 +61,12 @@ public:
   BlinkType blink_type_;
   bool active_polarity_;
 
-  void callbackStateMessage(const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
+  uint16_t current_reservation_lock_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
+  uint16_t current_shutdown_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_INACTIVE_FOR_SHUTDOWN;
+
+  void callbackReservationStateMessage(const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
+  void callbackShutdownStateMessage(const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
+  void changeLampCondition(const uint16_t state);
   void publishLamp(const bool value);
   void startLampBlinkOperation(BlinkType type);
   double getTimerDuration(void);

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -32,7 +32,7 @@ public:
   {
     FAST_BLINK,
     SLOW_BLINK,
-    TWO_BLINKS
+    TWO_BLINKS_TWICE
   };
 
   // Publisher
@@ -49,6 +49,10 @@ public:
   #define BLINK_FAST_OFF_DURATION (0.5)
   #define BLINK_SLOW_ON_DURATION (1.0)
   #define BLINK_SLOW_OFF_DURATION (1.0)
+
+  #define UNLIMITED_BLINKS (-1)
+  #define TWO_BLINKS_MAX_RETRY_COUNT (2)
+
   #define ACTIVE_POLARITY (false)
 
   std::array<double, 4> two_blinks_duration_table_ = {
@@ -72,6 +76,8 @@ public:
   rclcpp::TimerBase::SharedPtr blink_timer_;
   uint64_t blink_sequence_;
   BlinkType blink_type_;
+  int blink_retry_count_;
+  int max_blink_retry_count_;
   bool active_polarity_;
   uint16_t receive_reservation_state_;
   uint16_t current_reservation_state_;
@@ -82,7 +88,7 @@ public:
   void callbackShutdownStateMessage(const shutdown_manager_msgs::msg::StateShutdown::ConstSharedPtr msg);
   void onTimer(void);
   void publishLamp(const bool value);
-  void startLampBlinkOperation(const BlinkType type);
+  void startLampBlinkOperation(const BlinkType type, const int max_blink_retry_count);
   double getTimerDuration(void);
   void lampBlinkOperationCallback(void);
   void setPeriod(const double new_period);

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -32,7 +32,7 @@ public:
   {
     FAST_BLINK,
     SLOW_BLINK,
-    TWO_BLINKS_TWICE
+    TWO_BLINKS_UNTIL_EXPIRATION
   };
 
   // Publisher
@@ -50,7 +50,7 @@ public:
   #define BLINK_SLOW_ON_DURATION (1.0)
   #define BLINK_SLOW_OFF_DURATION (1.0)
 
-  #define UNLIMITED_BLINKS (-1)
+  #define BLINK_INDENFINITELY (-1)
   #define TWO_BLINKS_MAX_RETRY_COUNT (2)
 
   #define ACTIVE_POLARITY (false)

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -68,7 +68,7 @@ public:
     BLINK_SLOW_ON_DURATION
   };
 
-  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::TimerBase::SharedPtr main_proc_timer_;
   rclcpp::TimerBase::SharedPtr blink_timer_;
   uint64_t blink_sequence_;
   BlinkType blink_type_;

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include "autoware_state_machine_msgs/msg/state_lock.hpp"
 #include "dio_ros_driver/msg/dio_port.hpp"
+#include "shutdown_manager_msgs/msg/state_shutdown.hpp"
 
 namespace delivery_reservation_lamp_manager
 {
@@ -38,7 +39,7 @@ public:
 
   // Subscription
   rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_reservation_lock_state_;
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_shutdown_state_;
+  rclcpp::Subscription<shutdown_manager_msgs::msg::StateShutdown>::SharedPtr sub_shutdown_state_;
 
   #define BLINK_FAST_ON_DURATION (0.5)
   #define BLINK_FAST_OFF_DURATION (0.5)
@@ -62,11 +63,10 @@ public:
   bool active_polarity_;
 
   uint16_t current_reservation_lock_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
-  uint16_t current_shutdown_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_INACTIVE_FOR_SHUTDOWN;
+  uint16_t current_shutdown_state_ = shutdown_manager_msgs::msg::StateShutdown::STATE_INACTIVE_FOR_SHUTDOWN;
 
   void callbackReservationStateMessage(const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
-  void callbackShutdownStateMessage(const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
-  void changeLampCondition(const uint16_t state);
+  void callbackShutdownStateMessage(const shutdown_manager_msgs::msg::StateShutdown::ConstSharedPtr msg);
   void publishLamp(const bool value);
   void startLampBlinkOperation(BlinkType type);
   double getTimerDuration(void);

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -73,10 +73,10 @@ public:
   uint64_t blink_sequence_;
   BlinkType blink_type_;
   bool active_polarity_;
-  uint16_t receive_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
-  uint16_t current_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
-  uint16_t receive_shutdown_state_ = shutdown_manager_msgs::msg::StateShutdown::STATE_INACTIVE_FOR_SHUTDOWN;
-  uint16_t current_shutdown_state_ = shutdown_manager_msgs::msg::StateShutdown::STATE_INACTIVE_FOR_SHUTDOWN;
+  uint16_t receive_reservation_state_;
+  uint16_t current_reservation_state_;
+  uint16_t receive_shutdown_state_;
+  uint16_t current_shutdown_state_;
 
   void callbackReservationStateMessage(const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
   void callbackShutdownStateMessage(const shutdown_manager_msgs::msg::StateShutdown::ConstSharedPtr msg);

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -27,28 +27,42 @@ public:
   explicit DeliveryReservationLampManager(const rclcpp::NodeOptions & options);
   ~DeliveryReservationLampManager();
 
+  enum BlinkType
+  {
+    FAST,
+    SLOW
+  };
+
   // Publisher
   rclcpp::Publisher<dio_ros_driver::msg::DIOPort>::SharedPtr pub_delivery_reservation_lamp_;
 
   // Subscription
   rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_state_;
 
-  #define BLINK_ON_DURATION (1.0)
-  #define BLINK_OFF_DURATION (1.0)
+  #define BLINK_FAST_ON_DURATION (0.5)
+  #define BLINK_FAST_OFF_DURATION (0.5)
+  #define BLINK_SLOW_ON_DURATION (1.0)
+  #define BLINK_SLOW_OFF_DURATION (1.0)
   #define ACTIVE_POLARITY (false)
 
-  std::array<double, 2> blink_duration_table_ = {
-    BLINK_OFF_DURATION,
-    BLINK_ON_DURATION
+  std::array<double, 2> fast_blink_duration_table_ = {
+    BLINK_FAST_OFF_DURATION,
+    BLINK_FAST_ON_DURATION
+  };
+
+  std::array<double, 2> slow_blink_duration_table_ = {
+    BLINK_SLOW_OFF_DURATION,
+    BLINK_SLOW_ON_DURATION
   };
 
   rclcpp::TimerBase::SharedPtr blink_timer_;
   uint64_t blink_sequence_;
+  BlinkType blink_type_;
   bool active_polarity_;
 
   void callbackStateMessage(const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
   void publishLamp(const bool value);
-  void startLampBlinkOperation(void);
+  void startLampBlinkOperation(BlinkType type);
   double getTimerDuration(void);
   void lampBlinkOperationCallback(void);
   void setPeriod(const double new_period);

--- a/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
+++ b/include/delivery_reservation_lamp_manager/delivery_reservation_lamp_manager.hpp
@@ -39,7 +39,7 @@ public:
   rclcpp::Publisher<dio_ros_driver::msg::DIOPort>::SharedPtr pub_delivery_reservation_lamp_;
 
   // Subscription
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_reservation_lock_state_;
+  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_reservation_state_;
   rclcpp::Subscription<shutdown_manager_msgs::msg::StateShutdown>::SharedPtr sub_shutdown_state_;
 
   #define TWO_BLINKS_ON_DURATION (0.2)
@@ -73,8 +73,8 @@ public:
   uint64_t blink_sequence_;
   BlinkType blink_type_;
   bool active_polarity_;
-  uint16_t receive_reservation_lock_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
-  uint16_t current_reservation_lock_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
+  uint16_t receive_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
+  uint16_t current_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
   uint16_t receive_shutdown_state_ = shutdown_manager_msgs::msg::StateShutdown::STATE_INACTIVE_FOR_SHUTDOWN;
   uint16_t current_shutdown_state_ = shutdown_manager_msgs::msg::StateShutdown::STATE_INACTIVE_FOR_SHUTDOWN;
 

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <depend>rclcpp</depend>
   <depend>dio_ros_driver</depend>
   <depend>autoware_state_machine_msgs</depend>
+  <depend>shutdown_manager_msgs</depend>
   <depend>rclcpp_components</depend>
 
   <depend>builtin_interfaces</depend>

--- a/src/delivery_reservation_lamp_manager.cpp
+++ b/src/delivery_reservation_lamp_manager.cpp
@@ -29,7 +29,7 @@ DeliveryReservationLampManager::DeliveryReservationLampManager(
     rclcpp::QoS{3}.transient_local(),
     std::bind(&DeliveryReservationLampManager::callbackReservationStateMessage, this, std::placeholders::_1)
   );
-  sub_shutdown_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateLock>(
+  sub_shutdown_state_ = this->create_subscription<shutdown_manager_msgs::msg::StateShutdown>(
     "/shutdown_manager/state",
     rclcpp::QoS{3}.transient_local(),
     std::bind(&DeliveryReservationLampManager::callbackShutdownStateMessage, this, std::placeholders::_1)

--- a/src/delivery_reservation_lamp_manager.cpp
+++ b/src/delivery_reservation_lamp_manager.cpp
@@ -112,9 +112,10 @@ void DeliveryReservationLampManager::onTimer(void)
   current_shutdown_state_ = receive_shutdown_state_;
 
   blink_timer_->cancel();
-  if (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_STANDBY_FOR_SHUTDOWN) {
+  if ((current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_STANDBY_FOR_SHUTDOWN) ||
+    (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_START_OF_SHUTDOWN)) {
     startLampBlinkOperation(BlinkType::FAST_BLINK);
-  } else if (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_START_OF_SHUTDOWN) {
+  } else if (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_SUCCESSFUL_SHUTDOWN_INITIATION) {
     startLampBlinkOperation(BlinkType::TWO_BLINKS);
   } else {
     if (current_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_OFF) {

--- a/src/delivery_reservation_lamp_manager.cpp
+++ b/src/delivery_reservation_lamp_manager.cpp
@@ -24,6 +24,11 @@ DeliveryReservationLampManager::DeliveryReservationLampManager(
   const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
 : Node("delivery_reservation_lamp_manager", options)
 {
+  receive_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
+  current_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
+  receive_shutdown_state_ = shutdown_manager_msgs::msg::StateShutdown::STATE_INACTIVE_FOR_SHUTDOWN;
+  current_shutdown_state_ = shutdown_manager_msgs::msg::StateShutdown::STATE_INACTIVE_FOR_SHUTDOWN;
+
   sub_reservation_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateLock>(
     "/autoware_state_machine/lock_state",
     rclcpp::QoS{3}.transient_local(),

--- a/src/delivery_reservation_lamp_manager.cpp
+++ b/src/delivery_reservation_lamp_manager.cpp
@@ -114,14 +114,14 @@ void DeliveryReservationLampManager::onTimer(void)
   blink_timer_->cancel();
   if ((current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_STANDBY_FOR_SHUTDOWN) ||
     (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_START_OF_SHUTDOWN)) {
-    startLampBlinkOperation(BlinkType::FAST_BLINK, UNLIMITED_BLINKS);
+    startLampBlinkOperation(BlinkType::FAST_BLINK, BLINK_INDENFINITELY);
   } else if (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_SUCCESSFUL_SHUTDOWN_INITIATION) {
-    startLampBlinkOperation(BlinkType::TWO_BLINKS_TWICE, TWO_BLINKS_MAX_RETRY_COUNT);
+    startLampBlinkOperation(BlinkType::TWO_BLINKS_UNTIL_EXPIRATION, TWO_BLINKS_MAX_RETRY_COUNT);
   } else {
     if (current_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_OFF) {
       publishLamp(false);
     } else if (current_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_VERIFICATION) {
-      startLampBlinkOperation(BlinkType::SLOW_BLINK, UNLIMITED_BLINKS);
+      startLampBlinkOperation(BlinkType::SLOW_BLINK, BLINK_INDENFINITELY);
     } else {
       publishLamp(true);
     }
@@ -155,7 +155,7 @@ double DeliveryReservationLampManager::getTimerDuration(void)
       blink_sequence_ = 0;
     }
     return fast_blink_duration_table_.at(blink_sequence_);
-  } else if (blink_type_ == BlinkType::TWO_BLINKS_TWICE) {
+  } else if (blink_type_ == BlinkType::TWO_BLINKS_UNTIL_EXPIRATION) {
     if (two_blinks_duration_table_.size() <= blink_sequence_) {
       blink_retry_count_++;
       blink_sequence_ = 0;
@@ -179,7 +179,7 @@ void DeliveryReservationLampManager::lampBlinkOperationCallback(void)
 
   // If the maximum count of retries is exceeded,
   //  the LED will turn off and stop blinking.
-  if ((max_blink_retry_count_ != UNLIMITED_BLINKS) &&
+  if ((max_blink_retry_count_ != BLINK_INDENFINITELY) &&
     (blink_retry_count_ >= max_blink_retry_count_)) {
     publishLamp(false);
     return;

--- a/src/delivery_reservation_lamp_manager.cpp
+++ b/src/delivery_reservation_lamp_manager.cpp
@@ -108,14 +108,14 @@ void DeliveryReservationLampManager::onTimer(void)
 
   blink_timer_->cancel();
   if (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_STANDBY_FOR_SHUTDOWN) {
-    startLampBlinkOperation(BlinkType::FAST);
+    startLampBlinkOperation(BlinkType::FAST_BLINK);
   } else if (current_shutdown_state_ == shutdown_manager_msgs::msg::StateShutdown::STATE_START_OF_SHUTDOWN) {
     startLampBlinkOperation(BlinkType::TWO_BLINKS);
   } else {
     if (current_reservation_lock_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_OFF) {
       publishLamp(false);
     } else if (current_reservation_lock_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_VERIFICATION) {
-      startLampBlinkOperation(BlinkType::SLOW);
+      startLampBlinkOperation(BlinkType::SLOW_BLINK);
     } else {
       publishLamp(true);
     }
@@ -141,7 +141,7 @@ void DeliveryReservationLampManager::startLampBlinkOperation(const BlinkType typ
 
 double DeliveryReservationLampManager::getTimerDuration(void)
 {
-  if (blink_type_ == BlinkType::FAST) {
+  if (blink_type_ == BlinkType::FAST_BLINK) {
     if (fast_blink_duration_table_.size() <= blink_sequence_) {
       blink_sequence_ = 0;
     }

--- a/src/delivery_reservation_lamp_manager.cpp
+++ b/src/delivery_reservation_lamp_manager.cpp
@@ -40,14 +40,14 @@ DeliveryReservationLampManager::DeliveryReservationLampManager(
 
   active_polarity_ = ACTIVE_POLARITY;
 
-  // Timer
-  std::chrono::milliseconds timer_period_msec;
-  timer_period_msec = std::chrono::duration_cast<std::chrono::milliseconds>(
+  // Main Proc Timer
+  std::chrono::milliseconds main_proc_timer_period_msec;
+  main_proc_timer_period_msec = std::chrono::duration_cast<std::chrono::milliseconds>(
     std::chrono::duration<double>(1.0 / 10.0));
   
-  auto timer_callback = std::bind(&DeliveryReservationLampManager::onTimer, this);
-  timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
-    this->get_clock(), timer_period_msec, std::move(timer_callback),
+  auto main_proc_timer_callback = std::bind(&DeliveryReservationLampManager::onTimer, this);
+  main_proc_timer_ = std::make_shared<rclcpp::GenericTimer<decltype(main_proc_timer_callback)>>(
+    this->get_clock(), main_proc_timer_period_msec, std::move(main_proc_timer_callback),
     this->get_node_base_interface()->get_context()
   );
 
@@ -62,7 +62,7 @@ DeliveryReservationLampManager::DeliveryReservationLampManager(
     this->get_node_base_interface()->get_context()
   );
 
-  this->get_node_timers_interface()->add_timer(timer_, nullptr);
+  this->get_node_timers_interface()->add_timer(main_proc_timer_, nullptr);
   this->get_node_timers_interface()->add_timer(blink_timer_, nullptr);
   blink_timer_->cancel();
 

--- a/src/delivery_reservation_lamp_manager.cpp
+++ b/src/delivery_reservation_lamp_manager.cpp
@@ -83,9 +83,10 @@ void DeliveryReservationLampManager::publishLamp(const bool value)
   pub_delivery_reservation_lamp_->publish(msg);
 }
 
-void DeliveryReservationLampManager::startLampBlinkOperation(void)
+void DeliveryReservationLampManager::startLampBlinkOperation(BlinkType type)
 {
   blink_sequence_ = 0;
+  blink_type_ = type;
   double duration = getTimerDuration();
 
   setPeriod(duration);
@@ -93,10 +94,17 @@ void DeliveryReservationLampManager::startLampBlinkOperation(void)
 
 double DeliveryReservationLampManager::getTimerDuration(void)
 {
-  if (blink_duration_table_.size() <= blink_sequence_) {
-    blink_sequence_ = 0;
+  if (blink_type_ == BlinkType::FAST) {
+    if (fast_blink_duration_table_.size() <= blink_sequence_) {
+      blink_sequence_ = 0;
+    }
+    return fast_blink_duration_table_.at(blink_sequence_);
+  } else {
+    if (slow_blink_duration_table_.size() <= blink_sequence_) {
+      blink_sequence_ = 0;
+    }
+    return slow_blink_duration_table_.at(blink_sequence_);
   }
-  return blink_duration_table_.at(blink_sequence_);
 }
 
 void DeliveryReservationLampManager::lampBlinkOperationCallback(void)


### PR DESCRIPTION
## Description

* Added BlinkType definition and modified to change blink duration.
* Added process to subscribe to shutdown status from `shutdown_manager`.
* Modify README to match implementation.

## Related Links

eve-autonomy/proj_launch#7

## Review Procedure

 * [x] Make sure the description is valid.
 * [x] Make sure that what is described in the description matches the implementation.